### PR TITLE
Update table up to 1.12.1

### DIFF
--- a/table.md
+++ b/table.md
@@ -1,22 +1,41 @@
 | package                                           | architectures                                                 |
 |---------------------------------------------------|---------------------------------------------------------------|
 | pytorch-1.0.0-py3.7_cuda10.0.130_cudnn7.4.1_1     | sm_30, sm_35, sm_50, sm_60, sm_61, sm_70, sm_75               |
-| pytorch-1.0.0-py3.7_cuda8.0.61_cudnn7.1.2_1       | sm_20, sm_35, sm_37, sm_50, sm_52, sm_53, sm_60, sm_61        |
+| pytorch-1.0.0-py3.7_cuda8.0.61_cudnn7.1.2_1       | sm_35, sm_50, sm_60, sm_61                                    |
 | pytorch-1.0.0-py3.7_cuda9.0.176_cudnn7.4.1_1      | sm_35, sm_37, sm_50, sm_52, sm_53, sm_60, sm_61, sm_70        |
 | pytorch-1.0.1-py3.7_cuda10.0.130_cudnn7.4.2_0     | sm_35, sm_50, sm_60, sm_61, sm_70, sm_75                      |
 | pytorch-1.0.1-py3.7_cuda10.0.130_cudnn7.4.2_2     | sm_35, sm_50, sm_60, sm_61, sm_70, sm_75                      |
-| pytorch-1.0.1-py3.7_cuda8.0.61_cudnn7.1.2_0       | sm_35, sm_37, sm_50, sm_52, sm_53, sm_60, sm_61               |
-| pytorch-1.0.1-py3.7_cuda8.0.61_cudnn7.1.2_2       | sm_35, sm_37, sm_50, sm_52, sm_53, sm_60, sm_61               |
+| pytorch-1.0.1-py3.7_cuda8.0.61_cudnn7.1.2_0       | sm_35, sm_50, sm_60, sm_61                                    |
+| pytorch-1.0.1-py3.7_cuda8.0.61_cudnn7.1.2_2       | sm_35, sm_50, sm_60, sm_61                                    |
 | pytorch-1.0.1-py3.7_cuda9.0.176_cudnn7.4.2_0      | sm_35, sm_50, sm_60, sm_61, sm_70                             |
-| pytorch-1.0.1-py3.7_cuda9.0.176_cudnn7.4.2_2      | sm_35, sm_50, sm_60, sm_70                                    |
+| pytorch-1.0.1-py3.7_cuda9.0.176_cudnn7.4.2_2      | sm_35, sm_50, sm_60, sm_61, sm_70                             |
 | pytorch-1.1.0-py3.7_cuda10.0.130_cudnn7.5.1_0     | sm_35, sm_50, sm_60, sm_61, sm_70, sm_75                      |
 | pytorch-1.1.0-py3.7_cuda9.0.176_cudnn7.5.1_0      | sm_35, sm_50, sm_60, sm_61, sm_70                             |
+| pytorch-1.10.0-py3.7_cuda10.2_cudnn7.6.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.10.0-py3.7_cuda11.1_cudnn8.0.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.10.0-py3.7_cuda11.3_cudnn8.2.0_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.10.1-py3.7_cuda10.2_cudnn7.6.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.10.1-py3.7_cuda11.1_cudnn8.0.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.10.1-py3.7_cuda11.3_cudnn8.2.0_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.10.2-py3.7_cuda10.2_cudnn7.6.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.10.2-py3.7_cuda11.1_cudnn8.0.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.10.2-py3.7_cuda11.3_cudnn8.2.0_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.11.0-py3.7_cuda10.2_cudnn7.6.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.11.0-py3.7_cuda11.1_cudnn8.0.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.11.0-py3.7_cuda11.3_cudnn8.2.0_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.11.0-py3.7_cuda11.5_cudnn8.3.2_0        | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86        |
+| pytorch-1.12.0-py3.7_cuda10.2_cudnn7.6.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.12.0-py3.7_cuda11.3_cudnn8.3.2_0        | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86        |
+| pytorch-1.12.0-py3.7_cuda11.6_cudnn8.3.2_0        | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86        |
+| pytorch-1.12.1-py3.7_cuda10.2_cudnn7.6.5_0        | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.12.1-py3.7_cuda11.3_cudnn8.3.2_0        | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86        |
+| pytorch-1.12.1-py3.7_cuda11.6_cudnn8.3.2_0        | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86        |
 | pytorch-1.2.0+cu92-py3.7_cuda9.2.148_cudnn7.6.2_0 | sm_35, sm_50, sm_60, sm_61, sm_70                             |
 | pytorch-1.2.0-py3.7_cuda10.0.130_cudnn7.6.2_0     | sm_35, sm_50, sm_60, sm_61, sm_70, sm_75                      |
 | pytorch-1.2.0-py3.7_cuda9.2.148_cudnn7.6.2_0      | sm_35, sm_50, sm_60, sm_61, sm_70                             |
 | pytorch-1.3.0-py3.7_cuda10.0.130_cudnn7.6.3_0     | sm_30, sm_35, sm_50, sm_60, sm_61, sm_70, sm_75               |
 | pytorch-1.3.0-py3.7_cuda10.1.243_cudnn7.6.3_0     | sm_30, sm_35, sm_50, sm_60, sm_61, sm_70, sm_75               |
-| pytorch-1.3.0-py3.7_cuda9.2.148_cudnn7.6.3_0      | sm_35, sm_50, sm_60, sm_61, sm_70                             |
+| pytorch-1.3.0-py3.7_cuda9.2.148_cudnn7.6.3_0      | sm_30, sm_35, sm_50, sm_60, sm_61, sm_70                      |
 | pytorch-1.3.1-py3.7_cuda10.0.130_cudnn7.6.3_0     | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
 | pytorch-1.3.1-py3.7_cuda10.1.243_cudnn7.6.3_0     | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
 | pytorch-1.3.1-py3.7_cuda9.2.148_cudnn7.6.3_0      | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70                      |
@@ -34,17 +53,19 @@
 | pytorch-1.6.0-py3.7_cuda9.2.148_cudnn7.6.3_0      | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70                      |
 | pytorch-1.7.0-py3.7_cuda10.1.243_cudnn7.6.3_0     | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
 | pytorch-1.7.0-py3.7_cuda10.2.89_cudnn7.6.5_0      | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
-| pytorch-1.7.0-py3.7_cuda11.0.221_cudnn8.0.3_0     | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80               |
+| pytorch-1.7.0-py3.7_cuda11.0.221_cudnn8.0.3_0     | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80        |
 | pytorch-1.7.0-py3.7_cuda9.2.148_cudnn7.6.3_0      | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70                      |
 | pytorch-1.7.1-py3.7_cuda10.1.243_cudnn7.6.3_0     | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
 | pytorch-1.7.1-py3.7_cuda10.2.89_cudnn7.6.5_0      | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
 | pytorch-1.7.1-py3.7_cuda11.0.221_cudnn8.0.5_0     | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80        |
-| pytorch-1.7.1-py3.7_cuda9.2.148_cudnn7.6.3_0      | sm_37, sm_50, sm_60, sm_61, sm_70                             |
+| pytorch-1.7.1-py3.7_cuda9.2.148_cudnn7.6.3_0      | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70                      |
 | pytorch-1.8.0-py3.7_cuda10.1_cudnn7.6.3_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
 | pytorch-1.8.0-py3.7_cuda10.2_cudnn7.6.5_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
 | pytorch-1.8.0-py3.7_cuda11.1_cudnn8.0.5_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
-| pytorch-1.8.1-py3.7_cuda10.1_cudnn7.6.3_0         | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75                      |
-| pytorch-1.8.1-py3.7_cuda10.2_cudnn7.6.5_0         | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75                      |
-| pytorch-1.8.1-py3.7_cuda11.1_cudnn8.0.5_0         | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86        |
-| pytorch-1.9.0-py3.7_cuda10.2_cudnn7.6.5_0         | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75                      |
-| pytorch-1.9.0-py3.7_cuda11.1_cudnn8.0.5_0         | sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86        |
+| pytorch-1.8.1-py3.7_cuda10.1_cudnn7.6.3_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.8.1-py3.7_cuda10.2_cudnn7.6.5_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.8.1-py3.7_cuda11.1_cudnn8.0.5_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.9.0-py3.7_cuda10.2_cudnn7.6.5_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.9.0-py3.7_cuda11.1_cudnn8.0.5_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |
+| pytorch-1.9.1-py3.7_cuda10.2_cudnn7.6.5_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75               |
+| pytorch-1.9.1-py3.7_cuda11.1_cudnn8.0.5_0         | sm_35, sm_37, sm_50, sm_60, sm_61, sm_70, sm_75, sm_80, sm_86 |


### PR DESCRIPTION
The table was left behind. I ran the script with nvidia-cuda-toolkit 10.1.243-3, Python 3.10 and latest versions of dependencies from PyPI (not using the requirements.txt)

Thanks for the table. Helped to see what is the status.